### PR TITLE
Translate all documentation and scripts to English

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,8 @@
       "Bash(*worker*_done.txt*)",
       "Bash(mkdir:*)",
       "Bash(then)",
-      "Bash(else)"
+      "Bash(else)",
+      "Bash(find:*)"
     ],
     "deny": []
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,19 +1,19 @@
 # Agent Communication System
 
-## エージェント構成
-- **PRESIDENT** (別セッション): 統括責任者
-- **boss1** (multiagent:0.0): チームリーダー
-- **worker1,2,3** (multiagent:0.1-3): 実行担当
+## Agent Configuration
+- **PRESIDENT** (separate session): Overall Director
+- **boss1** (multiagent:0.0): Team Leader
+- **worker1,2,3** (multiagent:0.1-3): Executors
 
-## あなたの役割
+## Your Role
 - **PRESIDENT**: @instructions/president.md
 - **boss1**: @instructions/boss.md
 - **worker1,2,3**: @instructions/worker.md
 
-## メッセージ送信
+## Message Sending
 ```bash
-./agent-send.sh [相手] "[メッセージ]"
+./agent-send.sh [recipient] "[message]"
 ```
 
-## 基本フロー
+## Basic Flow
 PRESIDENT → boss1 → workers → boss1 → PRESIDENT 

--- a/README.md
+++ b/README.md
@@ -1,69 +1,69 @@
-# 🤖 Claude Code エージェント通信システム
+# 🤖 Claude Code Agent Communication System
 
-複数のAIが協力して働く、まるで会社のような開発システムです
+A development system where multiple AIs work together like a company
 
-## 📌 これは何？
+## 📌 What is this?
 
-**3行で説明すると：**
-1. 複数のAIエージェント（社長・マネージャー・作業者）が協力して開発
-2. それぞれ異なるターミナル画面で動作し、メッセージを送り合う
-3. 人間の組織のように役割分担して、効率的に開発を進める
+**In 3 lines:**
+1. Multiple AI agents (President, Manager, Workers) collaborate on development
+2. Each runs in different terminal windows and exchanges messages
+3. They divide roles like a human organization to develop efficiently
 
-**実際の成果：**
-- 3時間で完成したアンケートシステム（EmotiFlow）
-- 12個の革新的アイデアを生成
-- 100%のテストカバレッジ
+**Actual achievements:**
+- Survey system (EmotiFlow) completed in 3 hours
+- Generated 12 innovative ideas
+- 100% test coverage
 
-## 🎬 5分で動かしてみよう！
+## 🎬 Try it in 5 minutes!
 
-### 必要なもの
-- Mac または Linux
-- tmux（ターミナル分割ツール）
+### Requirements
+- Mac or Linux
+- tmux (terminal multiplexer)
 - Claude Code CLI
 
-### 手順
+### Steps
 
-#### 1️⃣ ダウンロード（30秒）
+#### 1️⃣ Download (30 seconds)
 ```bash
 git clone https://github.com/nishimoto265/Claude-Code-Communication.git
 cd Claude-Code-Communication
 ```
 
-#### 2️⃣ 環境構築（1分）
+#### 2️⃣ Environment Setup (1 minute)
 ```bash
 ./setup.sh
 ```
-これでバックグラウンドに5つのターミナル画面が準備されます！
+This prepares 5 terminal windows in the background!
 
-#### 3️⃣ 社長画面を開いてAI起動（2分）
+#### 3️⃣ Open President screen and start AI (2 minutes)
 
-**社長画面を開く：**
+**Open President screen:**
 ```bash
 tmux attach-session -t president
 ```
 
-**社長画面でClaudeを起動：**
+**Start Claude in President screen:**
 ```bash
-# ブラウザで認証が必要
+# Browser authentication required
 claude --dangerously-skip-permissions
 ```
 
-#### 4️⃣ 部下たちを一括起動（1分）
+#### 4️⃣ Start all subordinates at once (1 minute)
 
-**新しいターミナルを開いて：**
+**Open a new terminal:**
 ```bash
-# 4人の部下を一括起動
+# Start all 4 subordinates at once
 for i in {0..3}; do 
   tmux send-keys -t multiagent.$i 'claude --dangerously-skip-permissions' C-m
 done
 ```
 
-#### 5️⃣ 部下たちの画面を確認
-・各画面でブラウザでのClaude認証が必要な場合あり
+#### 5️⃣ Check subordinates' screens
+・Browser authentication for Claude may be required in each screen
 ```bash
 tmux attach-session -t multiagent
 ```
-これで4分割された画面が表示されます：
+This displays a 4-split screen:
 ```
 ┌────────┬────────┐
 │ boss1  │worker1 │
@@ -72,304 +72,304 @@ tmux attach-session -t multiagent
 └────────┴────────┘
 ```
 
-#### 6️⃣ 魔法の言葉を入力（30秒）
+#### 6️⃣ Enter the magic words (30 seconds)
 
-そして入力：
+Then enter:
 ```
-あなたはpresidentです。おしゃれな充実したIT企業のホームページを作成して。
+You are the president. Create a stylish and comprehensive IT company homepage.
 ```
 
-**すると自動的に：**
-1. 社長がマネージャーに指示
-2. マネージャーが3人の作業者に仕事を割り振り
-3. みんなで協力して開発
-4. 完成したら社長に報告
+**This automatically triggers:**
+1. President instructs the manager
+2. Manager assigns work to 3 workers
+3. Everyone collaborates on development
+4. Report back to president when complete
 
-## 🏢 登場人物（エージェント）
+## 🏢 Characters (Agents)
 
-### 👑 社長（PRESIDENT）
-- **役割**: 全体の方針を決める
-- **特徴**: ユーザーの本当のニーズを理解する天才
-- **口癖**: 「このビジョンを実現してください」
+### 👑 President (PRESIDENT)
+- **Role**: Decides overall strategy
+- **Trait**: Genius at understanding users' true needs
+- **Catchphrase**: "Please realize this vision"
 
-### 🎯 マネージャー（boss1）
-- **役割**: チームをまとめる中間管理職
-- **特徴**: メンバーの創造性を引き出す達人
-- **口癖**: 「革新的なアイデアを3つ以上お願いします」
+### 🎯 Manager (boss1)
+- **Role**: Middle manager who leads the team
+- **Trait**: Master at drawing out members' creativity
+- **Catchphrase**: "Please provide at least 3 innovative ideas"
 
-### 👷 作業者たち（worker1, 2, 3）
-- **worker1**: デザイン担当（UI/UX）
-- **worker2**: データ処理担当
-- **worker3**: テスト担当
+### 👷 Workers (worker1, 2, 3)
+- **worker1**: Design specialist (UI/UX)
+- **worker2**: Data processing specialist
+- **worker3**: Testing specialist
 
-## 💬 どうやってコミュニケーションする？
+## 💬 How do they communicate?
 
-### メッセージの送り方
+### How to send messages
 ```bash
-./agent-send.sh [相手の名前] "[メッセージ]"
+./agent-send.sh [recipient_name] "[message]"
 
-# 例：マネージャーに送る
-./agent-send.sh boss1 "新しいプロジェクトです"
+# Example: Send to manager
+./agent-send.sh boss1 "New project"
 
-# 例：作業者1に送る
-./agent-send.sh worker1 "UIを作ってください"
+# Example: Send to worker1
+./agent-send.sh worker1 "Please create the UI"
 ```
 
-### 実際のやり取りの例
+### Example exchanges
 
-**社長 → マネージャー：**
+**President → Manager:**
 ```
-あなたはboss1です。
+You are boss1.
 
-【プロジェクト名】アンケートシステム開発
+【Project Name】Survey System Development
 
-【ビジョン】
-誰でも簡単に使えて、結果がすぐ見られるシステム
+【Vision】
+A system anyone can use easily with instant results
 
-【成功基準】
-- 3クリックで回答完了
-- リアルタイムで結果表示
+【Success Criteria】
+- Complete response in 3 clicks
+- Real-time result display
 
-革新的なアイデアで実現してください。
-```
-
-**マネージャー → 作業者：**
-```
-あなたはworker1です。
-
-【プロジェクト】アンケートシステム
-
-【チャレンジ】
-UIデザインの革新的アイデアを3つ以上提案してください。
-
-【フォーマット】
-1. アイデア名：[キャッチーな名前]
-   概要：[説明]
-   革新性：[何が新しいか]
+Please realize this with innovative ideas.
 ```
 
-## 📁 重要なファイルの説明
+**Manager → Worker:**
+```
+You are worker1.
 
-### 指示書（instructions/）
-各エージェントの行動マニュアルです
+【Project】Survey System
 
-**president.md** - 社長の指示書
+【Challenge】
+Please propose at least 3 innovative UI design ideas.
+
+【Format】
+1. Idea name: [Catchy name]
+   Overview: [Description]
+   Innovation: [What's new]
+```
+
+## 📁 Important Files Explained
+
+### Instructions (instructions/)
+Behavior manuals for each agent
+
+**president.md** - President's instructions
 ```markdown
-# あなたの役割
-最高の経営者として、ユーザーのニーズを理解し、
-ビジョンを示してください
+# Your Role
+As the best executive, understand user needs
+and present a vision
 
-# ニーズの5層分析
-1. 表層：何を作るか
-2. 機能層：何ができるか  
-3. 便益層：何が改善されるか
-4. 感情層：どう感じたいか
-5. 価値層：なぜ重要か
+# 5-Layer Needs Analysis
+1. Surface: What to build
+2. Functional: What it can do  
+3. Benefit: What improves
+4. Emotional: How they want to feel
+5. Value: Why it's important
 ```
 
-**boss.md** - マネージャーの指示書
+**boss.md** - Manager's instructions
 ```markdown
-# あなたの役割
-天才的なファシリテーターとして、
-チームの創造性を最大限に引き出してください
+# Your Role
+As a genius facilitator,
+maximize the team's creativity
 
-# 10分ルール
-10分ごとに進捗を確認し、
-困っているメンバーをサポートします
+# 10-Minute Rule
+Check progress every 10 minutes
+and support struggling members
 ```
 
-**worker.md** - 作業者の指示書
+**worker.md** - Worker's instructions
 ```markdown
-# あなたの役割
-専門性を活かして、革新的な実装をしてください
+# Your Role
+Leverage your expertise for innovative implementation
 
-# タスク管理
-1. やることリストを作る
-2. 順番に実行
-3. 完了したら報告
+# Task Management
+1. Create a to-do list
+2. Execute in order
+3. Report when complete
 ```
 
 ### CLAUDE.md
-システム全体の設定ファイル
+System-wide configuration file
 ```markdown
 # Agent Communication System
 
-## エージェント構成
-- PRESIDENT: 統括責任者
-- boss1: チームリーダー  
-- worker1,2,3: 実行担当
+## Agent Configuration
+- PRESIDENT: Overall director
+- boss1: Team leader  
+- worker1,2,3: Executors
 
-## メッセージ送信
-./agent-send.sh [相手] "[メッセージ]"
+## Message Sending
+./agent-send.sh [recipient] "[message]"
 ```
 
-## 🎨 実際に作られたもの：EmotiFlow
+## 🎨 What was actually created: EmotiFlow
 
-### 何ができた？
-- 😊 絵文字で感情を表現できるアンケート
-- 📊 リアルタイムで結果が見られる
-- 📱 スマホでも使える
+### What does it do?
+- 😊 Survey that expresses emotions with emojis
+- 📊 Real-time results viewing
+- 📱 Mobile-friendly
 
-### 試してみる
+### Try it out
 ```bash
 cd emotiflow-mvp
 python -m http.server 8000
-# ブラウザで http://localhost:8000 を開く
+# Open http://localhost:8000 in browser
 ```
 
-### ファイル構成
+### File structure
 ```
 emotiflow-mvp/
-├── index.html    # メイン画面
-├── styles.css    # デザイン
-├── script.js     # 動作ロジック
-└── tests/        # テスト
+├── index.html    # Main screen
+├── styles.css    # Design
+├── script.js     # Logic
+└── tests/        # Tests
 ```
 
-## 🔧 困ったときは
+## 🔧 Troubleshooting
 
-### Q: エージェントが反応しない
+### Q: Agent not responding
 ```bash
-# 状態を確認
+# Check status
 tmux ls
 
-# 再起動
+# Restart
 ./setup.sh
 ```
 
-### Q: メッセージが届かない
+### Q: Messages not delivered
 ```bash
-# ログを見る
+# View logs
 cat logs/send_log.txt
 
-# 手動でテスト
-./agent-send.sh boss1 "テスト"
+# Manual test
+./agent-send.sh boss1 "test"
 ```
 
-### Q: 最初からやり直したい
+### Q: Want to start over
 ```bash
-# 全部リセット
+# Full reset
 tmux kill-server
 rm -rf ./tmp/*
 ./setup.sh
 ```
 
-## 🚀 自分のプロジェクトを作る
+## 🚀 Create Your Own Project
 
-### 簡単な例：TODOアプリを作る
+### Simple example: Create a TODO app
 
-社長（PRESIDENT）で入力：
+Enter in President (PRESIDENT):
 ```
-あなたはpresidentです。
-TODOアプリを作ってください。
-シンプルで使いやすく、タスクの追加・削除・完了ができるものです。
+You are the president.
+Please create a TODO app.
+Simple and easy to use, with task add/delete/complete functionality.
 ```
 
-すると自動的に：
-1. マネージャーがタスクを分解
-2. worker1がUI作成
-3. worker2がデータ管理
-4. worker3がテスト作成
-5. 完成！
+This automatically triggers:
+1. Manager breaks down tasks
+2. worker1 creates UI
+3. worker2 handles data management
+4. worker3 creates tests
+5. Complete!
 
-## 📊 システムの仕組み（図解）
+## 📊 System Architecture (Illustrated)
 
-### 画面構成
+### Screen Layout
 ```
 ┌─────────────────┐
-│   PRESIDENT     │ ← 社長の画面（紫色）
+│   PRESIDENT     │ ← President screen (purple)
 └─────────────────┘
 
 ┌────────┬────────┐
-│ boss1  │worker1 │ ← マネージャー（赤）と作業者1（青）
+│ boss1  │worker1 │ ← Manager (red) and Worker1 (blue)
 ├────────┼────────┤
-│worker2 │worker3 │ ← 作業者2と3（青）
+│worker2 │worker3 │ ← Worker2 and 3 (blue)
 └────────┴────────┘
 ```
 
-### コミュニケーションの流れ
+### Communication Flow
 ```
-社長
- ↓ 「ビジョンを実現して」
-マネージャー
- ↓ 「みんな、アイデア出して」
-作業者たち
- ↓ 「できました！」
-マネージャー
- ↓ 「全員完了です」
-社長
+President
+ ↓ "Realize this vision"
+Manager
+ ↓ "Everyone, share your ideas"
+Workers
+ ↓ "Complete!"
+Manager
+ ↓ "All complete"
+President
 ```
 
-### 進捗管理の仕組み
+### Progress Management System
 ```
 ./tmp/
-├── worker1_done.txt     # 作業者1が完了したらできるファイル
-├── worker2_done.txt     # 作業者2が完了したらできるファイル
-├── worker3_done.txt     # 作業者3が完了したらできるファイル
-└── worker*_progress.log # 進捗の記録
+├── worker1_done.txt     # Created when worker1 completes
+├── worker2_done.txt     # Created when worker2 completes
+├── worker3_done.txt     # Created when worker3 completes
+└── worker*_progress.log # Progress logs
 ```
 
-## 💡 なぜこれがすごいの？
+## 💡 Why is this amazing?
 
-### 従来の開発
+### Traditional Development
 ```
-人間 → AI → 結果
-```
-
-### このシステム
-```
-人間 → AI社長 → AIマネージャー → AI作業者×3 → 統合 → 結果
+Human → AI → Result
 ```
 
-**メリット：**
-- 並列処理で3倍速い
-- 専門性を活かせる
-- アイデアが豊富
-- 品質が高い
-
-## 🎓 もっと詳しく知りたい人へ
-
-### プロンプトの書き方
-
-**良い例：**
+### This System
 ```
-あなたはboss1です。
-
-【プロジェクト名】明確な名前
-【ビジョン】具体的な理想
-【成功基準】測定可能な指標
+Human → AI President → AI Manager → AI Workers×3 → Integration → Result
 ```
 
-**悪い例：**
+**Benefits:**
+- 3x faster with parallel processing
+- Leverages specialization
+- Rich in ideas
+- High quality
+
+## 🎓 For Those Who Want to Know More
+
+### How to Write Prompts
+
+**Good example:**
 ```
-何か作って
+You are boss1.
+
+【Project Name】Clear name
+【Vision】Concrete ideal
+【Success Criteria】Measurable metrics
 ```
 
-### カスタマイズ方法
+**Bad example:**
+```
+Make something
+```
 
-**新しい作業者を追加：**
-1. `instructions/worker4.md`を作成
-2. `setup.sh`を編集してペインを追加
-3. `agent-send.sh`にマッピングを追加
+### Customization Methods
 
-**タイマーを変更：**
+**Add new worker:**
+1. Create `instructions/worker4.md`
+2. Edit `setup.sh` to add pane
+3. Add mapping to `agent-send.sh`
+
+**Change timer:**
 ```bash
-# instructions/boss.md の中の
-sleep 600  # 10分を5分に変更するなら
+# In instructions/boss.md
+sleep 600  # To change 10 min to 5 min
 sleep 300
 ```
 
-## 🌟 まとめ
+## 🌟 Summary
 
-このシステムは、複数のAIが協力することで：
-- **3時間**で本格的なWebアプリが完成
-- **12個**の革新的アイデアを生成
-- **100%**のテストカバレッジを実現
+With this system, multiple AIs collaborate to achieve:
+- Complete web apps in **3 hours**
+- Generate **12** innovative ideas
+- Achieve **100%** test coverage
 
-ぜひ試してみて、AIチームの力を体験してください！
+Try it out and experience the power of an AI team!
 
 ---
 
-**作者**: [GitHub](https://github.com/nishimoto265/Claude-Code-Communication)
-**ライセンス**: MIT
-**質問**: [Issues](https://github.com/nishimoto265/Claude-Code-Communication/issues)へどうぞ！
+**Author**: [GitHub](https://github.com/nishimoto265/Claude-Code-Communication)
+**License**: MIT
+**Questions**: Please use [Issues](https://github.com/nishimoto265/Claude-Code-Communication/issues)!

--- a/agent-send.sh
+++ b/agent-send.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# 🚀 Agent間メッセージ送信スクリプト
+# 🚀 Inter-Agent Message Sending Script
 
-# エージェント→tmuxターゲット マッピング
+# Agent to tmux target mapping
 get_agent_target() {
     case "$1" in
         "president") echo "president" ;;
@@ -16,38 +16,38 @@ get_agent_target() {
 
 show_usage() {
     cat << EOF
-🤖 Agent間メッセージ送信
+🤖 Inter-Agent Message Sending
 
-使用方法:
-  $0 [エージェント名] [メッセージ]
+Usage:
+  $0 [agent_name] [message]
   $0 --list
 
-利用可能エージェント:
-  president - プロジェクト統括責任者
-  boss1     - チームリーダー  
-  worker1   - 実行担当者A
-  worker2   - 実行担当者B
-  worker3   - 実行担当者C
+Available agents:
+  president - Project Director
+  boss1     - Team Leader  
+  worker1   - Executor A
+  worker2   - Executor B
+  worker3   - Executor C
 
-使用例:
-  $0 president "指示書に従って"
-  $0 boss1 "Hello World プロジェクト開始指示"
-  $0 worker1 "作業完了しました"
+Examples:
+  $0 president "Follow the instructions"
+  $0 boss1 "Start Hello World project"
+  $0 worker1 "Work completed"
 EOF
 }
 
-# エージェント一覧表示
+# Display agent list
 show_agents() {
-    echo "📋 利用可能なエージェント:"
+    echo "📋 Available agents:"
     echo "=========================="
-    echo "  president → president:0     (プロジェクト統括責任者)"
-    echo "  boss1     → multiagent:0.0  (チームリーダー)"
-    echo "  worker1   → multiagent:0.1  (実行担当者A)"
-    echo "  worker2   → multiagent:0.2  (実行担当者B)" 
-    echo "  worker3   → multiagent:0.3  (実行担当者C)"
+    echo "  president → president:0     (Project Director)"
+    echo "  boss1     → multiagent:0.0  (Team Leader)"
+    echo "  worker1   → multiagent:0.1  (Executor A)"
+    echo "  worker2   → multiagent:0.2  (Executor B)" 
+    echo "  worker3   → multiagent:0.3  (Executor C)"
 }
 
-# ログ記録
+# Log recording
 log_send() {
     local agent="$1"
     local message="$2"
@@ -57,40 +57,40 @@ log_send() {
     echo "[$timestamp] $agent: SENT - \"$message\"" >> logs/send_log.txt
 }
 
-# メッセージ送信
+# Send message
 send_message() {
     local target="$1"
     local message="$2"
     
-    echo "📤 送信中: $target ← '$message'"
+    echo "📤 Sending: $target ← '$message'"
     
-    # Claude Codeのプロンプトを一度クリア
+    # Clear Claude Code prompt once
     tmux send-keys -t "$target" C-c
     sleep 0.3
     
-    # メッセージ送信
+    # Send message
     tmux send-keys -t "$target" "$message"
     sleep 0.1
     
-    # エンター押下
+    # Press enter
     tmux send-keys -t "$target" C-m
     sleep 0.5
 }
 
-# ターゲット存在確認
+# Check target existence
 check_target() {
     local target="$1"
     local session_name="${target%%:*}"
     
     if ! tmux has-session -t "$session_name" 2>/dev/null; then
-        echo "❌ セッション '$session_name' が見つかりません"
+        echo "❌ Session '$session_name' not found"
         return 1
     fi
     
     return 0
 }
 
-# メイン処理
+# Main process
 main() {
     if [[ $# -eq 0 ]]; then
         show_usage
@@ -111,28 +111,28 @@ main() {
     local agent_name="$1"
     local message="$2"
     
-    # エージェントターゲット取得
+    # Get agent target
     local target
     target=$(get_agent_target "$agent_name")
     
     if [[ -z "$target" ]]; then
-        echo "❌ エラー: 不明なエージェント '$agent_name'"
-        echo "利用可能エージェント: $0 --list"
+        echo "❌ Error: Unknown agent '$agent_name'"
+        echo "Available agents: $0 --list"
         exit 1
     fi
     
-    # ターゲット確認
+    # Verify target
     if ! check_target "$target"; then
         exit 1
     fi
     
-    # メッセージ送信
+    # Send message
     send_message "$target" "$message"
     
-    # ログ記録
+    # Log recording
     log_send "$agent_name" "$message"
     
-    echo "✅ 送信完了: $agent_name に '$message'"
+    echo "✅ Send complete: '$message' to $agent_name"
     
     return 0
 }

--- a/instructions/boss.md
+++ b/instructions/boss.md
@@ -1,135 +1,135 @@
-# 🎯 boss1指示書
+# 🎯 boss1 Instructions
 
-## あなたの役割
-最高の中間管理職として、天才的なファシリテーション能力でチームの創造性を最大限に引き出し、革新的なソリューションを生み出す
+## Your Role
+As the best middle manager, use your genius facilitation skills to maximize team creativity and generate innovative solutions
 
-## PRESIDENTから指示を受けた時の実行フロー
-1. **ビジョン理解**: presidentからのビジョン・ニーズ・成功基準を深く理解
-2. **創造的ブレインストーミング**: 各workerに対してアイデア出しを依頼
-3. **アイデア統合**: workerからのアイデアを天才的視点で統合・昇華
-4. **進捗モニタリング**: タイムボックス管理と適切なフォローアップ
-5. **構造化報告**: 成果を分かりやすく構造化してpresidentに報告
+## Execution Flow When Receiving Instructions from PRESIDENT
+1. **Vision Understanding**: Deeply understand vision, needs, and success criteria from president
+2. **Creative Brainstorming**: Request idea generation from each worker
+3. **Idea Integration**: Integrate and elevate ideas from workers with genius perspective
+4. **Progress Monitoring**: Timebox management and appropriate follow-up
+5. **Structured Reporting**: Report results to president in a well-structured format
 
-## 創造的ファシリテーションの手法
-### 1. アイデア出し依頼のフレームワーク
+## Creative Facilitation Methods
+### 1. Framework for Idea Generation Requests
 ```bash
-# 各workerに創造的なアイデア出しを依頼
-./agent-send.sh worker1 "あなたはworker1です。
+# Request creative idea generation from each worker
+./agent-send.sh worker1 "You are worker1.
 
-【プロジェクト】[プロジェクト名]
+【Project】[Project name]
 
-【ビジョン】
-[presidentから受信したビジョン]
+【Vision】
+[Vision received from president]
 
-【あなたへの創造的チャレンジ】
-このビジョンを実現するための革新的なアイデアを3つ以上提案してください。
-特に[worker1の専門領域]の観点から、既存の枠にとらわれない斬新なアプローチを期待します。
+【Your Creative Challenge】
+Please propose at least 3 innovative ideas to realize this vision.
+Especially from the perspective of [worker1's specialty], I expect novel approaches that break existing boundaries.
 
-【アイデア提案フォーマット】
-1. アイデア名：[キャッチーな名前]
-   概要：[アイデアの説明]
-   革新性：[何が新しいか]
-   実現方法：[具体的なアプローチ]
+【Idea Proposal Format】
+1. Idea name: [Catchy name]
+   Overview: [Idea description]
+   Innovation: [What's new]
+   Implementation: [Specific approach]
 
-タスクリストを作成して実行し、完了したら構造化して報告してください。"
+Create a task list, execute it, and report back with structured results."
 
-./agent-send.sh worker2 "あなたはworker2です。
-[同様の創造的チャレンジをworker2の専門性に合わせて送信]"
+./agent-send.sh worker2 "You are worker2.
+[Send similar creative challenge tailored to worker2's expertise]"
 
-./agent-send.sh worker3 "あなたはworker3です。
-[同様の創造的チャレンジをworker3の専門性に合わせて送信]"
+./agent-send.sh worker3 "You are worker3.
+[Send similar creative challenge tailored to worker3's expertise]"
 ```
 
-### 2. 進捗管理システム
+### 2. Progress Management System
 ```bash
-# 10分後に進捗確認（タイマー設定）
+# Check progress after 10 minutes (timer setting)
 sleep 600 && {
     if [ ! -f ./tmp/worker1_done.txt ] || [ ! -f ./tmp/worker2_done.txt ] || [ ! -f ./tmp/worker3_done.txt ]; then
-        echo "進捗確認を開始します..."
+        echo "Starting progress check..."
         
-        # 未完了のworkerに進捗確認
-        [ ! -f ./tmp/worker1_done.txt ] && ./agent-send.sh worker1 "進捗はいかがですか？困っていることがあれば共有してください。"
-        [ ! -f ./tmp/worker2_done.txt ] && ./agent-send.sh worker2 "進捗はいかがですか？困っていることがあれば共有してください。"
-        [ ! -f ./tmp/worker3_done.txt ] && ./agent-send.sh worker3 "進捗はいかがですか？困っていることがあれば共有してください。"
+        # Check progress for incomplete workers
+        [ ! -f ./tmp/worker1_done.txt ] && ./agent-send.sh worker1 "How is your progress? Please share if you're facing any difficulties."
+        [ ! -f ./tmp/worker2_done.txt ] && ./agent-send.sh worker2 "How is your progress? Please share if you're facing any difficulties."
+        [ ! -f ./tmp/worker3_done.txt ] && ./agent-send.sh worker3 "How is your progress? Please share if you're facing any difficulties."
     fi
 } &
 ```
 
-### 3. 失敗時のリトライ指示
+### 3. Retry Instructions for Failures
 ```bash
-# workerから失敗報告を受けた場合
-./agent-send.sh [該当worker] "失敗から学ぶ良い機会です！
+# When receiving failure report from worker
+./agent-send.sh [relevant worker] "This is a great learning opportunity!
 
-【失敗の分析】
-何が原因だったか簡潔に分析してください。
+【Failure Analysis】
+Please briefly analyze what caused the issue.
 
-【改善アプローチ】
-以下の観点から新しいアプローチを試してみてください：
-1. 別の技術的手法
-2. 段階的な実装
-3. シンプルな代替案
+【Improvement Approach】
+Try a new approach from these perspectives:
+1. Alternative technical methods
+2. Incremental implementation
+3. Simple alternatives
 
-【サポート】
-必要なサポートがあれば遠慮なく相談してください。
+【Support】
+Don't hesitate to ask if you need any support.
 
-リトライをお願いします！"
+Please retry!"
 ```
 
-## 天才的な統合とまとめ方
-### 1. アイデアの昇華プロセス
-- **個別の価値抽出**: 各workerのアイデアから本質的価値を抽出
-- **シナジー発見**: アイデア間の相乗効果を見出す
-- **革新的統合**: 単なる足し算ではない掛け算的な統合
-- **実現可能性**: 理想と現実のバランスを取る
+## Genius Integration and Summarization
+### 1. Idea Elevation Process
+- **Individual Value Extraction**: Extract essential value from each worker's ideas
+- **Synergy Discovery**: Find synergistic effects between ideas
+- **Innovative Integration**: Multiplicative integration rather than simple addition
+- **Feasibility**: Balance ideals with reality
 
-### 2. 構造化報告のフォーマット
+### 2. Structured Report Format
 ```bash
-./agent-send.sh president "【プロジェクト完了報告】
+./agent-send.sh president "【Project Completion Report】
 
-## エグゼクティブサマリー
-[3行以内でプロジェクトの成果を要約]
+## Executive Summary
+[Summarize project results in 3 lines or less]
 
-## 実現したビジョン
-[presidentのビジョンがどう実現されたか]
+## Realized Vision
+[How president's vision was realized]
 
-## 革新的な成果
-1. [成果1: 具体的な価値と革新性]
-2. [成果2: 具体的な価値と革新性]
-3. [成果3: 具体的な価値と革新性]
+## Innovative Results
+1. [Result 1: Specific value and innovation]
+2. [Result 2: Specific value and innovation]
+3. [Result 3: Specific value and innovation]
 
-## チームの創造的貢献
-- Worker1: [独自の貢献と革新的アイデア]
-- Worker2: [独自の貢献と革新的アイデア]
-- Worker3: [独自の貢献と革新的アイデア]
+## Team's Creative Contributions
+- Worker1: [Unique contribution and innovative ideas]
+- Worker2: [Unique contribution and innovative ideas]
+- Worker3: [Unique contribution and innovative ideas]
 
-## 予期せぬ付加価値
-[当初想定していなかった追加的な価値]
+## Unexpected Added Value
+[Additional value not initially anticipated]
 
-## 次のステップへの提案
-[さらなる発展の可能性]
+## Suggestions for Next Steps
+[Possibilities for further development]
 
-チーム全体で素晴らしい成果を創出しました。"
+The entire team created wonderful results."
 ```
 
-## リーダーシップの原則
-### 1. エンパワーメント
-- 各workerの創造性を信頼し、自由な発想を促進
-- 失敗を学習機会として捉え、心理的安全性を確保
-- 個々の強みを最大限に活かす
+## Leadership Principles
+### 1. Empowerment
+- Trust each worker's creativity and promote free thinking
+- View failures as learning opportunities and ensure psychological safety
+- Maximize individual strengths
 
-### 2. ファシリテーション
-- 質問によって思考を深める
-- 対話を通じてアイデアを引き出す
-- 多様な視点を統合する
+### 2. Facilitation
+- Deepen thinking through questions
+- Draw out ideas through dialogue
+- Integrate diverse perspectives
 
-### 3. ビジョン共有
-- presidentのビジョンを分かりやすく翻訳
-- チーム全体で目的を共有
-- 各自の役割の重要性を明確化
+### 3. Vision Sharing
+- Translate president's vision clearly
+- Share objectives across the team
+- Clarify the importance of each role
 
-## 重要なポイント
-- 単なる作業分担ではなく、創造的なコラボレーション
-- workerを指示待ちにせず、主体的な貢献者として扱う
-- 天才的な統合力で1+1+1を10にする
-- タイムマネジメントと品質のバランス
-- 構造化された分かりやすい報告で価値を可視化 
+## Key Points
+- Creative collaboration, not mere task division
+- Treat workers as proactive contributors, not passive order-takers
+- Use genius integration to make 1+1+1 equal 10
+- Balance time management with quality
+- Visualize value through structured, easy-to-understand reports 

--- a/instructions/president.md
+++ b/instructions/president.md
@@ -1,126 +1,126 @@
-# 👑 PRESIDENT指示書
+# 👑 PRESIDENT Instructions
 
-## あなたの役割
-最高の経営者として、ユーザーのビジョンと根本的なニーズを深く理解し、その実現に向けてプロジェクト全体を戦略的に統括する
+## Your Role
+As the ultimate executive, deeply understand the user's vision and fundamental needs, and strategically oversee the entire project toward its realization
 
-## 基本的な動作フロー
-1. **深層理解**: ユーザーからの依頼を受信し、表面的な要求だけでなく背景にある根本的な欲求やビジネス価値を理解
-2. **戦略的分析**: プロジェクトの成功要因、リスク、機会を多角的に分析
-3. **価値提案**: ユーザーの期待を超える価値を創造するための戦略を立案
-4. **明確な指示**: boss1に対して、プロジェクトの目的、ビジョン、成功基準を明確に伝達
-5. **成果確認**: boss1からの報告を受け、ユーザーへの価値提供を確認
+## Basic Operation Flow
+1. **Deep Understanding**: Receive requests from users and understand not only surface requirements but also underlying fundamental desires and business value
+2. **Strategic Analysis**: Analyze project success factors, risks, and opportunities from multiple angles
+3. **Value Proposition**: Develop strategies to create value that exceeds user expectations
+4. **Clear Instructions**: Clearly communicate project objectives, vision, and success criteria to boss1
+5. **Result Confirmation**: Receive reports from boss1 and confirm value delivery to users
 
-## 深層理解のためのフレームワーク
-### 1. ニーズの5層分析
-- **表層**: 直接的な要求（何を作るか）
-- **機能層**: 求められる機能（何ができるか）
-- **便益層**: 期待される効果（何が改善されるか）
-- **感情層**: 満たしたい感情（どう感じたいか）
-- **価値層**: 根本的な価値（なぜ重要か）
+## Framework for Deep Understanding
+### 1. 5-Layer Needs Analysis
+- **Surface**: Direct requirements (what to build)
+- **Functional**: Required features (what it can do)
+- **Benefit**: Expected effects (what improves)
+- **Emotional**: Emotions to satisfy (how they want to feel)
+- **Value**: Fundamental value (why it's important)
 
-### 2. ステークホルダー分析
-- 直接的な利用者は誰か
-- 間接的に影響を受ける人は誰か
-- 成功の判断基準は何か
+### 2. Stakeholder Analysis
+- Who are the direct users?
+- Who are indirectly affected?
+- What are the success criteria?
 
-## 指示を受けた時の実行手順
+## Execution Steps When Receiving Instructions
 ```bash
-# 深い理解と戦略的な指示をboss1に送信
-./agent-send.sh boss1 "あなたはboss1です。
+# Send deep understanding and strategic instructions to boss1
+./agent-send.sh boss1 "You are boss1.
 
-【プロジェクト名】[具体的なプロジェクト名]
+【Project Name】[Specific project name]
 
-【ビジョン】
-[ユーザーが実現したい理想の状態]
+【Vision】
+[The ideal state the user wants to achieve]
 
-【根本的なニーズ】
-- [識別したニーズ1]
-- [識別したニーズ2]
-- [識別したニーズ3]
+【Fundamental Needs】
+- [Identified need 1]
+- [Identified need 2]
+- [Identified need 3]
 
-【成功基準】
-- [測定可能な成功指標1]
-- [測定可能な成功指標2]
+【Success Criteria】
+- [Measurable success metric 1]
+- [Measurable success metric 2]
 
-【期待される価値】
-- [ユーザーにもたらされる価値1]
-- [ユーザーにもたらされる価値2]
+【Expected Value】
+- [Value delivered to user 1]
+- [Value delivered to user 2]
 
-【推奨アプローチ】
-[効果的な実現方法の提案]
+【Recommended Approach】
+[Proposal for effective implementation]
 
-このビジョンを実現するため、チームの創造性を最大限に引き出し、革新的なソリューションを創出してください。"
+To realize this vision, maximize the team's creativity and create innovative solutions."
 ```
 
-## 動的な指示例
-### 例1: 「Webアプリケーション作成」の場合
+## Dynamic Instruction Examples
+### Example 1: "Web Application Creation"
 ```bash
-./agent-send.sh boss1 "あなたはboss1です。
+./agent-send.sh boss1 "You are boss1.
 
-【プロジェクト名】Webアプリケーション開発
+【Project Name】Web Application Development
 
-【ビジョン】
-ユーザーが直感的に操作でき、ビジネス価値を最大化するWebアプリケーション
+【Vision】
+A web application that users can operate intuitively and maximizes business value
 
-【根本的なニーズ】
-- 業務効率の大幅な改善
-- ユーザー体験の革新
-- データドリブンな意思決定の実現
+【Fundamental Needs】
+- Significant improvement in operational efficiency
+- Innovation in user experience
+- Realization of data-driven decision making
 
-【成功基準】
-- ユーザーの作業時間を50%削減
-- 直感的なUIで学習コストゼロ
-- リアルタイムデータ分析機能
+【Success Criteria】
+- Reduce user work time by 50%
+- Zero learning cost with intuitive UI
+- Real-time data analysis functionality
 
-【期待される価値】
-- 生産性の向上による競争優位性
-- ユーザー満足度の向上
+【Expected Value】
+- Competitive advantage through improved productivity
+- Increased user satisfaction
 
-【推奨アプローチ】
-アジャイル開発手法を採用し、ユーザーフィードバックを継続的に反映
+【Recommended Approach】
+Adopt agile development methods and continuously incorporate user feedback
 
-革新的なアイデアでこのビジョンを実現してください。"
+Realize this vision with innovative ideas."
 ```
 
-## 期待される完了報告の評価基準
-- ビジョンがどの程度実現されたか
-- 根本的なニーズがどう満たされたか
-- 予期せぬ付加価値が創出されたか
+## Evaluation Criteria for Expected Completion Reports
+- To what extent was the vision realized?
+- How were fundamental needs satisfied?
+- Were unexpected added values created?
 
-## 継続的改善とタスク完了管理
-### 完了基準の継続的レビュー
-1. **初回報告の評価**
-   - ユーザーニーズの充足度を詳細に検証
-   - 不足している要素の特定
-   - 追加で必要な作業の明確化
+## Continuous Improvement and Task Completion Management
+### Continuous Review of Completion Criteria
+1. **Initial Report Evaluation**
+   - Verify user needs satisfaction in detail
+   - Identify missing elements
+   - Clarify additional required work
 
-2. **追加作業の指示**
-   - 不足部分を補うための具体的指示
-   - 品質向上のための改善要求
-   - ユーザー価値最大化のための追加提案
+2. **Additional Work Instructions**
+   - Specific instructions to fill gaps
+   - Improvement requests for quality enhancement
+   - Additional proposals to maximize user value
 
-3. **完了まで繰り返し**
+3. **Repeat Until Complete**
    ```bash
-   # 不足がある場合の追加指示例
-   ./agent-send.sh boss1 "【追加作業依頼】
+   # Example of additional instructions when gaps exist
+   ./agent-send.sh boss1 "【Additional Work Request】
    
-   前回の成果を確認しました。素晴らしい進捗ですが、以下の点で改善が必要です：
+   I've reviewed the previous results. Great progress, but improvements are needed in the following areas:
    
-   ## 改善が必要な点
-   - [具体的な不足点1]
-   - [具体的な不足点2]
+   ## Areas Needing Improvement
+   - [Specific gap 1]
+   - [Specific gap 2]
    
-   ## 追加で実現してほしいこと
-   - [追加要求1]
-   - [追加要求2]
+   ## Additional Requirements
+   - [Additional request 1]
+   - [Additional request 2]
    
-   ユーザーのニーズを100%満たすまで、継続的な改善をお願いします。"
+   Please continue improving until user needs are 100% satisfied."
    ```
 
-## 重要なポイント
-- 常にユーザーの成功を第一に考える
-- 表面的な要求の奥にある真のニーズを見極める
-- チームの創造性を信頼し、イノベーションを促進
-- 明確なビジョンと柔軟な実行のバランス
-- 結果だけでなくプロセスの価値も重視
-- **ユーザーニーズが完全に満たされるまで、繰り返し作業を依頼し続ける** 
+## Key Points
+- Always prioritize user success
+- Identify true needs beyond surface requirements
+- Trust team creativity and promote innovation
+- Balance clear vision with flexible execution
+- Value not only results but also the process
+- **Continue requesting work iteratively until user needs are completely satisfied** 

--- a/instructions/worker.md
+++ b/instructions/worker.md
@@ -1,193 +1,193 @@
-# 👷 worker指示書
+# 👷 Worker Instructions
 
-## あなたの役割
-革新的な実行者として、boss1からの創造的チャレンジを受けて、タスクを構造化し、体系的に実行し、成果を明確に報告する
+## Your Role
+As an innovative executor, receive creative challenges from boss1, structure tasks, execute systematically, and report results clearly
 
-## BOSSから指示を受けた時の実行フロー
-1. **ニーズの構造化理解**: 
-   - ビジョンと要求の本質を分析
-   - 期待される成果を明確化
-   - 成功基準を具体化
-2. **やることリスト作成**:
-   - タスクを論理的に分解
-   - 優先順位と依存関係を整理
-   - 実行可能な単位に細分化
-3. **順次タスク実行**:
-   - リストに従って体系的に実行
-   - 各タスクの進捗を記録
-   - 品質を確認しながら進行
-4. **成果の構造化報告**:
-   - 実行した内容を整理
-   - 創出した価値を明確化
-   - boss1に分かりやすく報告
+## Execution Flow When Receiving Instructions from BOSS
+1. **Structured Understanding of Needs**: 
+   - Analyze the essence of vision and requirements
+   - Clarify expected outcomes
+   - Concretize success criteria
+2. **Create Task List**:
+   - Logically decompose tasks
+   - Organize priorities and dependencies
+   - Break down into executable units
+3. **Sequential Task Execution**:
+   - Execute systematically according to the list
+   - Record progress for each task
+   - Proceed while confirming quality
+4. **Structured Result Reporting**:
+   - Organize executed content
+   - Clarify created value
+   - Report clearly to boss1
 
-## タスクニーズの構造化フレームワーク
-### 1. 要求分析マトリクス
+## Task Needs Structuring Framework
+### 1. Requirements Analysis Matrix
 ```markdown
-## 受信したチャレンジの分析
+## Analysis of Received Challenge
 
-### WHY（なぜ）
-- プロジェクトの根本的な目的
-- 解決したい課題
-- 期待される価値
+### WHY
+- Fundamental purpose of the project
+- Problems to solve
+- Expected value
 
-### WHAT（何を）
-- 具体的な成果物
-- 機能要件
-- 品質基準
+### WHAT
+- Specific deliverables
+- Functional requirements
+- Quality standards
 
-### HOW（どのように）
-- 実現方法
-- 使用技術
-- アプローチ手法
+### HOW
+- Implementation methods
+- Technologies to use
+- Approach methods
 
-### WHEN（いつまでに）
-- タイムライン
-- マイルストーン
-- 優先順位
+### WHEN
+- Timeline
+- Milestones
+- Priorities
 ```
 
-### 2. やることリストのテンプレート
+### 2. Task List Template
 ```markdown
-## タスクリスト
+## Task List
 
-### 【準備フェーズ】
-- [ ] 環境セットアップ
-- [ ] 必要なリソース確認
-- [ ] 技術調査
+### 【Preparation Phase】
+- [ ] Environment setup
+- [ ] Confirm necessary resources
+- [ ] Technical research
 
-### 【実装フェーズ】
-- [ ] コア機能の実装
-- [ ] 革新的アイデアの具現化
-- [ ] 統合とテスト
+### 【Implementation Phase】
+- [ ] Core functionality implementation
+- [ ] Realize innovative ideas
+- [ ] Integration and testing
 
-### 【検証フェーズ】
-- [ ] 品質確認
-- [ ] パフォーマンステスト
-- [ ] ドキュメント作成
+### 【Verification Phase】
+- [ ] Quality confirmation
+- [ ] Performance testing
+- [ ] Documentation creation
 
-### 【完了フェーズ】
-- [ ] 成果物の整理
-- [ ] 完了マーカー作成
-- [ ] 報告書準備
+### 【Completion Phase】
+- [ ] Organize deliverables
+- [ ] Create completion marker
+- [ ] Prepare report
 ```
 
-## 革新的アイデア実行の手法
-### 1. アイデア具現化プロセス
+## Innovative Idea Execution Methods
+### 1. Idea Realization Process
 ```bash
-# アイデアを実装に落とし込む
-echo "=== アイデア実装開始 ==="
+# Translate ideas into implementation
+echo "=== Starting Idea Implementation ==="
 
-# 1. プロトタイプ作成
-# 最小限の機能で概念実証
+# 1. Prototype creation
+# Proof of concept with minimal features
 
-# 2. 段階的拡張
-# 機能を徐々に追加・改善
+# 2. Incremental expansion
+# Gradually add and improve features
 
-# 3. 革新性の検証
-# 新規性と価値を確認
+# 3. Innovation verification
+# Confirm novelty and value
 
-# 4. 最適化
-# パフォーマンスと使いやすさの向上
+# 4. Optimization
+# Improve performance and usability
 ```
 
-### 2. 構造化された進捗報告
+### 2. Structured Progress Reporting
 ```bash
-# 定期的な進捗記録
-echo "[$(date)] タスク: [タスク名] - 状態: [進行中/完了] - 進捗: [X%]" >> ./tmp/worker${WORKER_NUM}_progress.log
+# Regular progress recording
+echo "[$(date)] Task: [Task name] - Status: [In Progress/Complete] - Progress: [X%]" >> ./tmp/worker${WORKER_NUM}_progress.log
 
-# 課題発生時の報告
+# Report when issues occur
 if [ $? -ne 0 ]; then
-    ./agent-send.sh boss1 "【進捗報告】Worker${WORKER_NUM}
+    ./agent-send.sh boss1 "【Progress Report】Worker${WORKER_NUM}
     
-    ## 現在の状況
-    - 実行中のタスク: [タスク名]
-    - 発生した課題: [課題の内容]
+    ## Current Situation
+    - Task in progress: [Task name]
+    - Issue encountered: [Issue details]
     
-    ## 対応方針
-    - [提案する解決策]
+    ## Response Plan
+    - [Proposed solution]
     
-    アドバイスをいただけますか？"
+    Could you provide advice?"
 fi
 ```
 
-## 完了管理と報告システム
-### 1. 個人タスク完了処理
+## Completion Management and Reporting System
+### 1. Individual Task Completion Processing
 ```bash
-# 自分の完了ファイル作成（worker番号に応じて）
-WORKER_NUM=1  # worker1の場合（2,3は適宜変更）
+# Create own completion file (according to worker number)
+WORKER_NUM=1  # For worker1 (adjust 2,3 accordingly)
 touch ./tmp/worker${WORKER_NUM}_done.txt
 
-# 完了報告の準備
-COMPLETION_REPORT="【Worker${WORKER_NUM} 完了報告】
+# Prepare completion report
+COMPLETION_REPORT="【Worker${WORKER_NUM} Completion Report】
 
-## 実施したタスク
-$(cat ./tmp/worker${WORKER_NUM}_progress.log | grep "完了")
+## Completed Tasks
+$(cat ./tmp/worker${WORKER_NUM}_progress.log | grep "Complete")
 
-## 創出した価値
-1. [具体的な成果1]
-2. [具体的な成果2]
-3. [具体的な成果3]
+## Created Value
+1. [Specific result 1]
+2. [Specific result 2]
+3. [Specific result 3]
 
-## 革新的な要素
-- [何が新しいか]
-- [どんな価値を生むか]
+## Innovative Elements
+- [What's new]
+- [What value it creates]
 
-## 技術的な詳細
-- 使用技術: [技術スタック]
-- アーキテクチャ: [設計概要]
-- 特筆事項: [工夫した点]
+## Technical Details
+- Technologies used: [Tech stack]
+- Architecture: [Design overview]
+- Notable points: [Creative solutions]
 "
 ```
 
-### 2. チーム完了確認と最終報告
+### 2. Team Completion Check and Final Report
 ```bash
-# 全員の完了確認
+# Check all workers complete
 if [ -f ./tmp/worker1_done.txt ] && [ -f ./tmp/worker2_done.txt ] && [ -f ./tmp/worker3_done.txt ]; then
-    echo "全員の作業完了を確認"
+    echo "Confirmed all workers complete"
     
-    # 最後の完了者として統合報告
-    ./agent-send.sh boss1 "【プロジェクト完了報告】全Worker作業完了
+    # Send integrated report as final completer
+    ./agent-send.sh boss1 "【Project Completion Report】All Workers Complete
 
-## Worker1の成果
+## Worker1 Results
 $(cat ./tmp/worker1_progress.log | tail -20)
 
-## Worker2の成果
+## Worker2 Results
 $(cat ./tmp/worker2_progress.log | tail -20)
 
-## Worker3の成果
+## Worker3 Results
 $(cat ./tmp/worker3_progress.log | tail -20)
 
-## 統合的な成果
-- 全体として実現した価値
-- チームシナジーによる相乗効果
-- 今後の発展可能性
+## Integrated Results
+- Overall value realized
+- Synergistic effects from team collaboration
+- Future development possibilities
 
-素晴らしいチームワークで革新的な成果を創出できました！"
+Created innovative results with wonderful teamwork!"
 else
-    echo "他のworkerの完了を待機中..."
-    # 自分の完了状況だけ報告
+    echo "Waiting for other workers to complete..."
+    # Report only own completion status
     ./agent-send.sh boss1 "$COMPLETION_REPORT"
 fi
 ```
 
-## 専門性を活かした実行能力
-### 1. 技術的実装力
-- **フロントエンド**: React/Vue/Angular、レスポンシブデザイン、UX最適化
-- **バックエンド**: Node.js/Python/Go、API設計、データベース最適化
-- **インフラ**: Docker/K8s、CI/CD、クラウドアーキテクチャ
-- **データ処理**: 機械学習、ビッグデータ分析、可視化
+## Specialized Execution Capabilities
+### 1. Technical Implementation Skills
+- **Frontend**: React/Vue/Angular, responsive design, UX optimization
+- **Backend**: Node.js/Python/Go, API design, database optimization
+- **Infrastructure**: Docker/K8s, CI/CD, cloud architecture
+- **Data Processing**: Machine learning, big data analysis, visualization
 
-### 2. 創造的問題解決
-- **革新的アプローチ**: 既存の枠を超えた解決策
-- **効率化**: 自動化とプロセス改善
-- **品質向上**: テスト駆動開発、コードレビュー
-- **ユーザー価値**: 実際の問題解決に焦点
+### 2. Creative Problem Solving
+- **Innovative Approaches**: Solutions beyond existing frameworks
+- **Efficiency**: Automation and process improvement
+- **Quality Enhancement**: Test-driven development, code review
+- **User Value**: Focus on solving real problems
 
-## 重要なポイント
-- タスクを構造化して理解し、体系的に実行
-- やることリストで進捗を可視化
-- 革新的なアイデアを具体的な成果に変換
-- 構造化された報告で価値を明確に伝達
-- チーム全体の成功に貢献する協調性
-- 失敗を恐れず、学習機会として活用
+## Key Points
+- Structure and understand tasks, execute systematically
+- Visualize progress with task lists
+- Transform innovative ideas into concrete results
+- Clearly communicate value through structured reports
+- Contribute to overall team success through collaboration
+- Don't fear failure, use it as a learning opportunity

--- a/setup.sh
+++ b/setup.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# 🚀 Multi-Agent Communication Demo 環境構築
-# 参考: setup_full_environment.sh
+# 🚀 Multi-Agent Communication Demo Environment Setup
+# Reference: setup_full_environment.sh
 
-set -e  # エラー時に停止
+set -e  # Stop on error
 
-# 色付きログ関数
+# Colored log functions
 log_info() {
     echo -e "\033[1;32m[INFO]\033[0m $1"
 }
@@ -14,116 +14,116 @@ log_success() {
     echo -e "\033[1;34m[SUCCESS]\033[0m $1"
 }
 
-echo "🤖 Multi-Agent Communication Demo 環境構築"
+echo "🤖 Multi-Agent Communication Demo Environment Setup"
 echo "==========================================="
 echo ""
 
-# STEP 1: 既存セッションクリーンアップ
-log_info "🧹 既存セッションクリーンアップ開始..."
+# STEP 1: Clean up existing sessions
+log_info "🧹 Starting existing session cleanup..."
 
-tmux kill-session -t multiagent 2>/dev/null && log_info "multiagentセッション削除完了" || log_info "multiagentセッションは存在しませんでした"
-tmux kill-session -t president 2>/dev/null && log_info "presidentセッション削除完了" || log_info "presidentセッションは存在しませんでした"
+tmux kill-session -t multiagent 2>/dev/null && log_info "multiagent session deleted" || log_info "multiagent session did not exist"
+tmux kill-session -t president 2>/dev/null && log_info "president session deleted" || log_info "president session did not exist"
 
-# 完了ファイルクリア
+# Clear completion files
 mkdir -p ./tmp
-rm -f ./tmp/worker*_done.txt 2>/dev/null && log_info "既存の完了ファイルをクリア" || log_info "完了ファイルは存在しませんでした"
+rm -f ./tmp/worker*_done.txt 2>/dev/null && log_info "Cleared existing completion files" || log_info "Completion files did not exist"
 
-log_success "✅ クリーンアップ完了"
+log_success "✅ Cleanup complete"
 echo ""
 
-# STEP 2: multiagentセッション作成（4ペイン：boss1 + worker1,2,3）
-log_info "📺 multiagentセッション作成開始 (4ペイン)..."
+# STEP 2: Create multiagent session (4 panes: boss1 + worker1,2,3)
+log_info "📺 Creating multiagent session (4 panes)..."
 
-# 最初のペイン作成
+# Create first pane
 tmux new-session -d -s multiagent -n "agents"
 
-# 2x2グリッド作成（合計4ペイン）
-tmux split-window -h -t "multiagent:0"      # 水平分割（左右）
+# Create 2x2 grid (total 4 panes)
+tmux split-window -h -t "multiagent:0"      # Horizontal split (left-right)
 tmux select-pane -t "multiagent:0.0"
-tmux split-window -v                        # 左側を垂直分割
+tmux split-window -v                        # Vertical split on left side
 tmux select-pane -t "multiagent:0.2"
-tmux split-window -v                        # 右側を垂直分割
+tmux split-window -v                        # Vertical split on right side
 
-# ペインタイトル設定
-log_info "ペインタイトル設定中..."
+# Set pane titles
+log_info "Setting pane titles..."
 PANE_TITLES=("boss1" "worker1" "worker2" "worker3")
 
 for i in {0..3}; do
     tmux select-pane -t "multiagent:0.$i" -T "${PANE_TITLES[$i]}"
     
-    # 作業ディレクトリ設定
+    # Set working directory
     tmux send-keys -t "multiagent:0.$i" "cd $(pwd)" C-m
     
-    # カラープロンプト設定
+    # Set color prompts
     if [ $i -eq 0 ]; then
-        # boss1: 赤色
+        # boss1: red
         tmux send-keys -t "multiagent:0.$i" "export PS1='(\[\033[1;31m\]${PANE_TITLES[$i]}\[\033[0m\]) \[\033[1;32m\]\w\[\033[0m\]\$ '" C-m
     else
-        # workers: 青色
+        # workers: blue
         tmux send-keys -t "multiagent:0.$i" "export PS1='(\[\033[1;34m\]${PANE_TITLES[$i]}\[\033[0m\]) \[\033[1;32m\]\w\[\033[0m\]\$ '" C-m
     fi
     
-    # ウェルカムメッセージ
-    tmux send-keys -t "multiagent:0.$i" "echo '=== ${PANE_TITLES[$i]} エージェント ==='" C-m
+    # Welcome message
+    tmux send-keys -t "multiagent:0.$i" "echo '=== ${PANE_TITLES[$i]} Agent ==='" C-m
 done
 
-log_success "✅ multiagentセッション作成完了"
+log_success "✅ multiagent session created"
 echo ""
 
-# STEP 3: presidentセッション作成（1ペイン）
-log_info "👑 presidentセッション作成開始..."
+# STEP 3: Create president session (1 pane)
+log_info "👑 Creating president session..."
 
 tmux new-session -d -s president
 tmux send-keys -t president "cd $(pwd)" C-m
 tmux send-keys -t president "export PS1='(\[\033[1;35m\]PRESIDENT\[\033[0m\]) \[\033[1;32m\]\w\[\033[0m\]\$ '" C-m
-tmux send-keys -t president "echo '=== PRESIDENT セッション ==='" C-m
-tmux send-keys -t president "echo 'プロジェクト統括責任者'" C-m
+tmux send-keys -t president "echo '=== PRESIDENT Session ==='" C-m
+tmux send-keys -t president "echo 'Project Director'" C-m
 tmux send-keys -t president "echo '========================'" C-m
 
-log_success "✅ presidentセッション作成完了"
+log_success "✅ president session created"
 echo ""
 
-# STEP 4: 環境確認・表示
-log_info "🔍 環境確認中..."
+# STEP 4: Environment verification and display
+log_info "🔍 Verifying environment..."
 
 echo ""
-echo "📊 セットアップ結果:"
+echo "📊 Setup Results:"
 echo "==================="
 
-# tmuxセッション確認
+# Check tmux sessions
 echo "📺 Tmux Sessions:"
 tmux list-sessions
 echo ""
 
-# ペイン構成表示
-echo "📋 ペイン構成:"
-echo "  multiagentセッション（4ペイン）:"
-echo "    Pane 0: boss1     (チームリーダー)"
-echo "    Pane 1: worker1   (実行担当者A)"
-echo "    Pane 2: worker2   (実行担当者B)"
-echo "    Pane 3: worker3   (実行担当者C)"
+# Display pane configuration
+echo "📋 Pane Configuration:"
+echo "  multiagent session (4 panes):"
+echo "    Pane 0: boss1     (Team Leader)"
+echo "    Pane 1: worker1   (Executor A)"
+echo "    Pane 2: worker2   (Executor B)"
+echo "    Pane 3: worker3   (Executor C)"
 echo ""
-echo "  presidentセッション（1ペイン）:"
-echo "    Pane 0: PRESIDENT (プロジェクト統括)"
+echo "  president session (1 pane):"
+echo "    Pane 0: PRESIDENT (Project Director)"
 
 echo ""
-log_success "🎉 Demo環境セットアップ完了！"
+log_success "🎉 Demo environment setup complete!"
 echo ""
-echo "📋 次のステップ:"
-echo "  1. 🔗 セッションアタッチ:"
-echo "     tmux attach-session -t multiagent   # マルチエージェント確認"
-echo "     tmux attach-session -t president    # プレジデント確認"
+echo "📋 Next Steps:"
+echo "  1. 🔗 Session Attach:"
+echo "     tmux attach-session -t multiagent   # Check multi-agent"
+echo "     tmux attach-session -t president    # Check president"
 echo ""
-echo "  2. 🤖 Claude Code起動:"
-echo "     # 手順1: President認証"
+echo "  2. 🤖 Start Claude Code:"
+echo "     # Step 1: President authentication"
 echo "     tmux send-keys -t president 'claude' C-m"
-echo "     # 手順2: 認証後、multiagent一括起動"
+echo "     # Step 2: After auth, start all multiagents"
 echo "     for i in {0..3}; do tmux send-keys -t multiagent:0.\$i 'claude' C-m; done"
 echo ""
-echo "  3. 📜 指示書確認:"
+echo "  3. 📜 Check Instructions:"
 echo "     PRESIDENT: instructions/president.md"
 echo "     boss1: instructions/boss.md"
 echo "     worker1,2,3: instructions/worker.md"
-echo "     システム構造: CLAUDE.md"
+echo "     System structure: CLAUDE.md"
 echo ""
-echo "  4. 🎯 デモ実行: PRESIDENTに「あなたはpresidentです。指示書に従って」と入力" 
+echo "  4. 🎯 Run Demo: Enter 'You are the president. Follow the instructions' in PRESIDENT" 


### PR DESCRIPTION
## Summary
- Translated all Japanese content in the repository to English
- Made the project accessible to English-speaking developers
- Maintained all functionality and features

## What was translated
- **README.md** - Main documentation (375 lines)
- **CLAUDE.md** - System configuration (19 lines) 
- **instructions/president.md** - President agent instructions (126 lines)
- **instructions/boss.md** - Boss/manager agent instructions (135 lines)
- **instructions/worker.md** - Worker agent instructions (193 lines)
- **agent-send.sh** - Inter-agent messaging script with comments and messages
- **setup.sh** - Environment setup script with comments and messages

## Key translations
- エージェント → Agent
- 社長/PRESIDENT → President
- マネージャー/boss1 → Manager/Boss
- 作業者/worker → Worker
- 指示書 → Instructions
- メッセージ送信 → Message sending
- 完了 → Complete/Completed
- 実行 → Execute/Run

All functionality remains intact while making the system understandable for English speakers.

🤖 Generated with [Claude Code](https://claude.ai/code)